### PR TITLE
Added installation of libu2f-udev apt dependency to allow install on bare kali 2022.4 vmware image

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -63,7 +63,7 @@ python3 -m pip install python-lzo cstruct ubi_reader
 sudo apt-get install -y python3-magic  openjdk-11-jdk unrar
 
 # for analyzer, initializer
-sudo apt-get install -y python3-bs4
+sudo apt-get install -y python3-bs4 libu2f-udev
 python3 -m pip install selenium
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 sudo dpkg -i google-chrome-stable_current_amd64.deb; sudo apt-get -fy install


### PR DESCRIPTION
Added missing `lib2uf-udev` dependency for installing the chromedriver for running install on a clean kali 2022.4 vmware image.